### PR TITLE
Do not install typing on python 3.7+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov
 docs/_build
 .hypothesis
 .html
+venv

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 from setuptools import setup, find_packages
 import re
 import os
+import sys
 
 
 def get_version():
@@ -19,6 +20,15 @@ def get_long_description():
     ])
 
 
+# Do not install typing on python 3.7+
+INSTALL_REQUIRES = [
+    'attrs > 16.0.0',
+    'six',
+]
+if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] <= 6):
+    INSTALL_REQUIRES.append("typing")
+
+
 setup(
     name='scrapy-rotating-proxies',
     version=get_version(),
@@ -29,11 +39,7 @@ setup(
     description="Rotating proxies for Scrapy",
     url='https://github.com/TeamHG-Memex/scrapy-rotating-proxies',
     packages=find_packages(exclude=['tests']),
-    install_requires=[
-        'attrs > 16.0.0',
-        'six',
-        'typing',
-    ],
+    install_requires=INSTALL_REQUIRES,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Installing `scrapy-rotating-proxies` on python 3.7+ on scrapy cloud introduces the following bugs when deploying:

`AttributeError: type object 'Callable' has no attribute '_abc_registry'`

This is due to the typing package being installed despite the use of python 3.9. This prevents the typing package from being installed on python 3.7+ to be compatible with scrapy cloud deploys.